### PR TITLE
[SDCafiine] Add support for more controllers...

### DIFF
--- a/plugins/sdcafiine/src/controllers.cpp
+++ b/plugins/sdcafiine/src/controllers.cpp
@@ -1,0 +1,129 @@
+#include <utils/logger.h>
+#include "controllers.h"
+
+VPADData vpad;
+s32 vpadError;
+
+KPADData pads[4];
+s32 padErrors[4];
+u32 padTypes[4];
+
+void initControllers() {
+	KPADInit();
+}
+
+void releaseControllers() {
+	for(int i = 0; i < 4; i++) {
+		padErrors[i] = WPADProbe(i, &padTypes[i]);
+		if(padErrors[i] == 0) {
+			WPADDisconnect(i);
+		}
+	}
+
+	//Clear buffers so future launches of SDCafiine don't read old data
+	memset(&vpad, 0, sizeof(VPADData));
+	vpadError = 0;
+
+	memset(pads, 0, sizeof(KPADData) * 4);
+	memset(padErrors, 0, sizeof(s32) * 4);
+	memset(padTypes, 0, sizeof(u32) * 4);
+}
+
+void pollControllers() {
+	VPADRead(0, &vpad, 1, &vpadError);
+
+	for(int i = 0; i < 4; i++) {
+		padErrors[i] = WPADProbe(i, &padTypes[i]);
+		if(padErrors[i] == 0) {
+			KPADRead(i, &pads[i], 1);
+		}
+	}
+}
+
+bool isButtonPressed(enum PadButton btn) {
+	if(vpadError == 0) {
+		switch (btn) {
+		case PAD_BTN_A:
+			if (vpad.btns_d & VPAD_BUTTON_A) return true;
+			break;
+
+		case PAD_BTN_UP:
+			if (vpad.btns_d & VPAD_BUTTON_UP) return true;
+			break;
+
+		case PAD_BTN_DOWN:
+			if (vpad.btns_d & VPAD_BUTTON_DOWN) return true;
+			break;
+
+		case PAD_BTN_L:
+			if (vpad.btns_d & VPAD_BUTTON_L) return true;
+			break;
+
+		case PAD_BTN_R:
+			if (vpad.btns_d & VPAD_BUTTON_R) return true;
+			break;
+
+		default:
+			break;
+		}
+	}
+
+	for(int i = 0; i < 4; i++) {
+		if(padErrors[i] == 0) {
+			if(pads[i].device_type < 2) {
+				switch(btn) {
+				case PAD_BTN_A:
+					if (pads[i].btns_d & WPAD_BUTTON_A) return true;
+					break;
+
+				case PAD_BTN_UP:
+					if (pads[i].btns_d & WPAD_BUTTON_UP) return true;
+					break;
+
+				case PAD_BTN_DOWN:
+					if (pads[i].btns_d & WPAD_BUTTON_DOWN) return true;
+					break;
+
+				case PAD_BTN_L:
+					if (pads[i].btns_d & WPAD_BUTTON_1) return true;
+					break;
+
+				case PAD_BTN_R:
+					if (pads[i].btns_d & WPAD_BUTTON_2) return true;
+					break;
+
+				default:
+					break;
+				}
+			}
+			else {
+				switch(btn) {
+				case PAD_BTN_A:
+					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_A) return true;
+					break;
+
+				case PAD_BTN_UP:
+					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_UP) return true;
+					break;
+
+				case PAD_BTN_DOWN:
+					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_DOWN) return true;
+					break;
+
+				case PAD_BTN_L:
+					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_L) return true;
+					break;
+
+				case PAD_BTN_R:
+					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_R) return true;
+					break;
+
+				default:
+					break;
+				}
+			}
+		}
+	}
+
+	return false;
+}

--- a/plugins/sdcafiine/src/controllers.h
+++ b/plugins/sdcafiine/src/controllers.h
@@ -1,0 +1,15 @@
+#include <dynamic_libs/vpad_functions.h>
+#include <dynamic_libs/padscore_functions.h>
+
+enum PadButton {
+	PAD_BTN_A,
+	PAD_BTN_UP,
+	PAD_BTN_DOWN,
+	PAD_BTN_L,
+	PAD_BTN_R
+};
+
+void initControllers();
+void releaseControllers();
+void pollControllers();
+bool isButtonPressed(enum PadButton btn);

--- a/plugins/sdcafiine/src/main.cpp
+++ b/plugins/sdcafiine/src/main.cpp
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <dynamic_libs/os_functions.h>
 #include <dynamic_libs/vpad_functions.h>
+#include <dynamic_libs/padscore_functions.h>
 #include <dynamic_libs/sys_functions.h>
 #include <dynamic_libs/fs_functions.h>
 #include <dynamic_libs/proc_ui_functions.h>
@@ -28,18 +29,19 @@ ON_APPLICATION_START(args) {
     InitOSFunctionPointers();
     InitSocketFunctionPointers(); //For logging
     InitVPadFunctionPointers(); //For logging
+    InitPadScoreFunctionPointers();
 
     log_init();
 
     if(FileReplacerUtils::setGroupAndOwnerID()) {
         //DEBUG_FUNCTION_LINE("SUCCESS\n");
     }
-	
+
     DEBUG_FUNCTION_LINE("SD mounted? %d\n",args.sd_mounted);
     DEBUG_FUNCTION_LINE("USB mounted? %d\n",args.usb_mounted);
-    
+
 	gSDInitDone = args.sd_mounted;
-	gUSBInitDone = args.usb_mounted;   
+	gUSBInitDone = args.usb_mounted;
 
     HandleMultiModPacks(OSGetTitleID());
 

--- a/plugins/sdcafiine/src/modpackSelector.cpp
+++ b/plugins/sdcafiine/src/modpackSelector.cpp
@@ -11,6 +11,7 @@
 
 #include <dynamic_libs/os_functions.h>
 #include <dynamic_libs/vpad_functions.h>
+#include <dynamic_libs/padscore_functions.h>
 #include <utils/logger.h>
 #include <utils/StringTools.h>
 #include <fs/FSUtils.h>
@@ -19,6 +20,141 @@
 #include "common/retain_vars.h"
 
 #define TEXT_SEL(x, text1, text2)           ((x) ? (text1) : (text2))
+
+enum PadButton {
+	PAD_BTN_A,
+	PAD_BTN_UP,
+	PAD_BTN_DOWN,
+	PAD_BTN_L,
+	PAD_BTN_R
+};
+
+VPADData vpad;
+s32 vpadError;
+
+KPADData pads[4];
+s32 padErrors[4];
+u32 padTypes[4];
+
+void initControllers() {
+	KPADInit();
+}
+
+void releaseControllers() {
+	for(int i = 0; i < 4; i++) {
+		padErrors[i] = WPADProbe(i, &padTypes[i]);
+		if(padErrors[i] == 0) {
+			WPADDisconnect(i);
+		}
+	}
+
+	//Clear buffers so future launches of SDCafiine don't read old data
+	memset(&vpad, 0, sizeof(VPADData));
+	vpadError = 0;
+
+	memset(pads, 0, sizeof(KPADData) * 4);
+	memset(padErrors, 0, sizeof(s32) * 4);
+	memset(padTypes, 0, sizeof(u32) * 4);
+}
+
+void pollControllers() {
+	VPADRead(0, &vpad, 1, &vpadError);
+
+	for(int i = 0; i < 4; i++) {
+		padErrors[i] = WPADProbe(i, &padTypes[i]);
+		if(padErrors[i] == 0) {
+			KPADRead(i, &pads[i], 1);
+		}
+	}
+}
+
+bool isButtonPressed(enum PadButton btn) {
+	if(vpadError == 0) {
+		switch (btn) {
+		case PAD_BTN_A:
+			if (vpad.btns_d & VPAD_BUTTON_A) return true;
+			break;
+
+		case PAD_BTN_UP:
+			if (vpad.btns_d & VPAD_BUTTON_UP) return true;
+			break;
+
+		case PAD_BTN_DOWN:
+			if (vpad.btns_d & VPAD_BUTTON_DOWN) return true;
+			break;
+
+		case PAD_BTN_L:
+			if (vpad.btns_d & VPAD_BUTTON_L) return true;
+			break;
+
+		case PAD_BTN_R:
+			if (vpad.btns_d & VPAD_BUTTON_R) return true;
+			break;
+
+		default:
+			break;
+		}
+	}
+
+	for(int i = 0; i < 4; i++) {
+		if(padErrors[i] == 0) {
+			if(pads[i].device_type < 2) {
+				switch(btn) {
+				case PAD_BTN_A:
+					if (pads[i].btns_d & WPAD_BUTTON_A) return true;
+					break;
+
+				case PAD_BTN_UP:
+					if (pads[i].btns_d & WPAD_BUTTON_UP) return true;
+					break;
+
+				case PAD_BTN_DOWN:
+					if (pads[i].btns_d & WPAD_BUTTON_DOWN) return true;
+					break;
+
+				case PAD_BTN_L:
+					if (pads[i].btns_d & WPAD_BUTTON_1) return true;
+					break;
+
+				case PAD_BTN_R:
+					if (pads[i].btns_d & WPAD_BUTTON_2) return true;
+					break;
+
+				default:
+					break;
+				}
+			}
+			else {
+				switch(btn) {
+				case PAD_BTN_A:
+					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_A) return true;
+					break;
+
+				case PAD_BTN_UP:
+					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_UP) return true;
+					break;
+
+				case PAD_BTN_DOWN:
+					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_DOWN) return true;
+					break;
+
+				case PAD_BTN_L:
+					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_L) return true;
+					break;
+
+				case PAD_BTN_R:
+					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_R) return true;
+					break;
+
+				default:
+					break;
+				}
+			}
+		}
+	}
+
+	return false;
+}
 
 void HandleMultiModPacks(u64 titleID/*,bool showMenu*/) {
 	gModFolder[0] = 0;
@@ -83,8 +219,7 @@ void HandleMultiModPacks(u64 titleID/*,bool showMenu*/) {
     int initScreen = 1;
     int x_offset = -2;
 
-    VPADData vpad;
-    s32 vpadError;
+    initControllers();
 
     OSScreenInit();
     u32 screen_buf0_size = OSScreenGetBufferSizeEx(0);
@@ -111,30 +246,32 @@ void HandleMultiModPacks(u64 titleID/*,bool showMenu*/) {
 
     while(1){
 
-        vpadError = -1;
-        VPADRead(0, &vpad, 1, &vpadError);
+        pollControllers();
 
-        if(vpadError == 0) {
-            if(vpad.btns_d & VPAD_BUTTON_A) {
-                wantToExit = 1;
-                initScreen = 1;
-            } else if(vpad.btns_d & VPAD_BUTTON_DOWN) {
-                selected++;
-                initScreen = 1;
-            } else if(vpad.btns_d & VPAD_BUTTON_UP) {
-                selected--;
-                initScreen = 1;
-            } else if(vpad.btns_d & VPAD_BUTTON_L) {
-                selected -= per_page;
-                initScreen = 1;
-            } else if(vpad.btns_d & VPAD_BUTTON_R) {
-                selected += per_page;
-                initScreen = 1;
-            }
-            if(selected < 0) selected = 0;
-            if(selected >= modPackListSize) selected = modPackListSize-1;
-            page = selected / per_page;
-        }
+		if (isButtonPressed(PAD_BTN_A)) {
+			wantToExit = 1;
+			initScreen = 1;
+		}
+		else if (isButtonPressed(PAD_BTN_DOWN)) {
+			selected++;
+			initScreen = 1;
+		}
+		else if (isButtonPressed(PAD_BTN_UP)) {
+			selected--;
+			initScreen = 1;
+		}
+		else if (isButtonPressed(PAD_BTN_L)) {
+			selected -= per_page;
+			initScreen = 1;
+		}
+		else if (isButtonPressed(PAD_BTN_R)) {
+			selected += per_page;
+			initScreen = 1;
+		}
+
+		if (selected < 0) selected = 0;
+		if (selected >= modPackListSize) selected = modPackListSize - 1;
+		page = selected / per_page;
 
         if(initScreen) {
             OSScreenClearBufferEx(0, 0);
@@ -182,6 +319,8 @@ void HandleMultiModPacks(u64 titleID/*,bool showMenu*/) {
     // Flip buffers
     OSScreenFlipBuffersEx(0);
     OSScreenFlipBuffersEx(1);
+
+    releaseControllers();
 
     free(screenbuffers);
 

--- a/plugins/sdcafiine/src/modpackSelector.cpp
+++ b/plugins/sdcafiine/src/modpackSelector.cpp
@@ -8,10 +8,9 @@
 #include <malloc.h>
 #include "modpackSelector.h"
 #include "common/common.h"
+#include "controllers.h"
 
 #include <dynamic_libs/os_functions.h>
-#include <dynamic_libs/vpad_functions.h>
-#include <dynamic_libs/padscore_functions.h>
 #include <utils/logger.h>
 #include <utils/StringTools.h>
 #include <fs/FSUtils.h>
@@ -20,141 +19,6 @@
 #include "common/retain_vars.h"
 
 #define TEXT_SEL(x, text1, text2)           ((x) ? (text1) : (text2))
-
-enum PadButton {
-	PAD_BTN_A,
-	PAD_BTN_UP,
-	PAD_BTN_DOWN,
-	PAD_BTN_L,
-	PAD_BTN_R
-};
-
-VPADData vpad;
-s32 vpadError;
-
-KPADData pads[4];
-s32 padErrors[4];
-u32 padTypes[4];
-
-void initControllers() {
-	KPADInit();
-}
-
-void releaseControllers() {
-	for(int i = 0; i < 4; i++) {
-		padErrors[i] = WPADProbe(i, &padTypes[i]);
-		if(padErrors[i] == 0) {
-			WPADDisconnect(i);
-		}
-	}
-
-	//Clear buffers so future launches of SDCafiine don't read old data
-	memset(&vpad, 0, sizeof(VPADData));
-	vpadError = 0;
-
-	memset(pads, 0, sizeof(KPADData) * 4);
-	memset(padErrors, 0, sizeof(s32) * 4);
-	memset(padTypes, 0, sizeof(u32) * 4);
-}
-
-void pollControllers() {
-	VPADRead(0, &vpad, 1, &vpadError);
-
-	for(int i = 0; i < 4; i++) {
-		padErrors[i] = WPADProbe(i, &padTypes[i]);
-		if(padErrors[i] == 0) {
-			KPADRead(i, &pads[i], 1);
-		}
-	}
-}
-
-bool isButtonPressed(enum PadButton btn) {
-	if(vpadError == 0) {
-		switch (btn) {
-		case PAD_BTN_A:
-			if (vpad.btns_d & VPAD_BUTTON_A) return true;
-			break;
-
-		case PAD_BTN_UP:
-			if (vpad.btns_d & VPAD_BUTTON_UP) return true;
-			break;
-
-		case PAD_BTN_DOWN:
-			if (vpad.btns_d & VPAD_BUTTON_DOWN) return true;
-			break;
-
-		case PAD_BTN_L:
-			if (vpad.btns_d & VPAD_BUTTON_L) return true;
-			break;
-
-		case PAD_BTN_R:
-			if (vpad.btns_d & VPAD_BUTTON_R) return true;
-			break;
-
-		default:
-			break;
-		}
-	}
-
-	for(int i = 0; i < 4; i++) {
-		if(padErrors[i] == 0) {
-			if(pads[i].device_type < 2) {
-				switch(btn) {
-				case PAD_BTN_A:
-					if (pads[i].btns_d & WPAD_BUTTON_A) return true;
-					break;
-
-				case PAD_BTN_UP:
-					if (pads[i].btns_d & WPAD_BUTTON_UP) return true;
-					break;
-
-				case PAD_BTN_DOWN:
-					if (pads[i].btns_d & WPAD_BUTTON_DOWN) return true;
-					break;
-
-				case PAD_BTN_L:
-					if (pads[i].btns_d & WPAD_BUTTON_1) return true;
-					break;
-
-				case PAD_BTN_R:
-					if (pads[i].btns_d & WPAD_BUTTON_2) return true;
-					break;
-
-				default:
-					break;
-				}
-			}
-			else {
-				switch(btn) {
-				case PAD_BTN_A:
-					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_A) return true;
-					break;
-
-				case PAD_BTN_UP:
-					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_UP) return true;
-					break;
-
-				case PAD_BTN_DOWN:
-					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_DOWN) return true;
-					break;
-
-				case PAD_BTN_L:
-					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_L) return true;
-					break;
-
-				case PAD_BTN_R:
-					if (pads[i].classic.btns_d & WPAD_CLASSIC_BUTTON_R) return true;
-					break;
-
-				default:
-					break;
-				}
-			}
-		}
-	}
-
-	return false;
-}
 
 void HandleMultiModPacks(u64 titleID/*,bool showMenu*/) {
 	gModFolder[0] = 0;


### PR DESCRIPTION
...on the modpack selector screen.

By including the Padscore functions, the modpack selector now also supports the Wii U Pro Controller, Wiimote, Wii Classic Controller and Wii Classic Controller Pro. This allows users to choose modpacks without being forced to use the Gamepad.

The changes are ported from [CreeperMario's fork of the original SDCafiine app](https://github.com/CreeperMario/SDCafiine/tree/padscore)