### PR TITLE
Enable LTO build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ INCLUDES	:=	include
 #---------------------------------------------------------------------------------
 CFLAGS	:=	-g -Wall -Werror -save-temps \
 			-ffunction-sections -fdata-sections \
+			-flto -ffat-lto-objects \
 			$(MACHDEP) \
 			$(BUILD_CFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ INCLUDES	:=	include
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-CFLAGS	:=	-g -O2 -Wall -Werror -save-temps \
+CFLAGS	:=	-g -Wall -Werror -save-temps \
 			-ffunction-sections -fdata-sections \
 			$(MACHDEP) \
 			$(BUILD_CFLAGS)

--- a/include/wups/common.h
+++ b/include/wups/common.h
@@ -38,11 +38,16 @@
 extern "C" {
 #endif
 
-#define WUPS_SECTION(x) __attribute__((__section__(".wups." x)))
+#ifdef __cplusplus
+#define WUPS_EXTERN_C extern "C"
+#else
+#define WUPS_EXTERN_C
+#endif
+
+#define WUPS_SECTION(x) WUPS_EXTERN_C __attribute__((__section__(".wups." x), used))
 
 #define WUPS_META(id, value)                                 \
-    extern const char wups_meta_##id[] WUPS_SECTION("meta"); \
-    const char wups_meta_##id[] = #id "=" value
+    WUPS_SECTION("meta") const char wups_meta_##id[] = #id "=" value
 
 #ifdef __cplusplus
 }

--- a/include/wups/function_patching.h
+++ b/include/wups/function_patching.h
@@ -148,9 +148,7 @@ typedef struct wups_loader_entry_t {
 #define WUPS_MUST_REPLACE_FOR_PROCESS(x, lib, function_name, targetProcess)                         WUPS_MUST_REPLACE_EX(NULL, NULL, real_##x, lib, my_##x, function_name, targetProcess)
 
 #define WUPS_MUST_REPLACE_EX(pAddress, vAddress, original_func, rpl_type, replace_func, replace_function_name, process) \
-    extern const wups_loader_entry_t wups_load_##replace_func                                                           \
-            WUPS_SECTION("load");                                                                                       \
-    const wups_loader_entry_t wups_load_##replace_func = {                                                              \
+    WUPS_SECTION("load") const wups_loader_entry_t wups_load_##replace_func = {                                         \
             .type      = WUPS_LOADER_ENTRY_FUNCTION_MANDATORY,                                                          \
             ._function = {                                                                                              \
                     .physical_address = (const void *) pAddress,                                                        \

--- a/include/wups/hooks.h
+++ b/include/wups/hooks.h
@@ -23,8 +23,7 @@ extern "C" {
 #endif
 
 #define WUPS_HOOK_EX(type_def, original_func)                                         \
-    extern const wups_loader_hook_t wups_hooks_##original_func WUPS_SECTION("hooks"); \
-    const wups_loader_hook_t wups_hooks_##original_func = {                           \
+    WUPS_SECTION("hooks") const wups_loader_hook_t wups_hooks_##original_func = {     \
             .type   = type_def,                                                       \
             .target = (const void *) &(original_func)}
 

--- a/include/wups/meta.h
+++ b/include/wups/meta.h
@@ -50,14 +50,11 @@ extern "C" {
     WUPS___FINI_WRAPPER();                                                                                          \
     WUPS_INIT_CONFIG_FUNCTIONS();                                                                                   \
     WUPS_META(buildtimestamp, __DATE__ " " __TIME__);                                                               \
-    extern const char wups_meta_plugin_name[] WUPS_SECTION("meta");                                                 \
-    const char wups_meta_plugin_name[] = __plugin_name;                                                             \
-    extern const char wups_meta_info_dump[] WUPS_SECTION("meta");                                                   \
-    const char wups_meta_info_dump[] = "(plugin: " __plugin_name ";"                                                \
+    WUPS_SECTION("meta") const char wups_meta_plugin_name[] = __plugin_name;                                        \
+    WUPS_SECTION("meta") const char wups_meta_info_dump[] = "(plugin: " __plugin_name ";"                           \
                                        "wups " WUPS_VERSION_STR ";"                                                 \
                                        "buildtime: " __DATE__ " " __TIME__ ")";                                     \
-    extern const char wups_meta_info_linking_order[] WUPS_SECTION("meta");                                          \
-    const char wups_meta_info_linking_order[] = "Loading \"" __plugin_name "\" failed.\n"                           \
+    WUPS_SECTION("meta") const char wups_meta_info_linking_order[] = "Loading \"" __plugin_name "\" failed.\n"      \
                                                 "Function \"wut_get_thread_specific\" returned unexpected value.\n" \
                                                 "Please check linking order (expected \"-lwups -lwut\")";
 


### PR DESCRIPTION
This PR includes changes to mark the important `.wups` sections with the "used" attribute. This ensures that even aggressive optimisations (e.g. LTO) will not remove the hooks and WUPS metadata.

Since the used attribute needs to be on the variable itself (not an `extern`), move all attributes to the used attribute. `extern` in C++ also implies C linkage, so specify C linkage.

With that groundwork in place, enable an LTO build. This isn't super important - the `used` attributes are needed for plugins to use LTO - but it's basically free to enable it for the library too, so why not?