### PR TITLE
feat: use std::string_view instead of std::string for identifiers

### DIFF
--- a/include/wups/config/WUPSConfigItemBoolean.h
+++ b/include/wups/config/WUPSConfigItemBoolean.h
@@ -89,12 +89,12 @@ WUPSConfigItemBoolean_AddToCategoryEx(WUPSConfigCategoryHandle cat,
 #include "WUPSConfigItem.h"
 #include <optional>
 #include <stdexcept>
-#include <string>
+#include <string_view>
 #include <wups/config_api.h>
 
 class WUPSConfigItemBoolean : public WUPSConfigItem {
 public:
-    static std::optional<WUPSConfigItemBoolean> CreateEx(std::optional<std::string> identifier,
+    static std::optional<WUPSConfigItemBoolean> CreateEx(std::optional<std::string_view> identifier,
                                                          std::string_view displayName,
                                                          bool defaultValue,
                                                          bool currentValue,
@@ -103,7 +103,7 @@ public:
                                                          std::string_view falseValue,
                                                          WUPSConfigAPIStatus &err) noexcept;
 
-    static WUPSConfigItemBoolean CreateEx(std::optional<std::string> identifier,
+    static WUPSConfigItemBoolean CreateEx(std::optional<std::string_view> identifier,
                                           std::string_view displayName,
                                           bool defaultValue,
                                           bool currentValue,
@@ -111,14 +111,14 @@ public:
                                           std::string_view trueValue,
                                           std::string_view falseValue);
 
-    static std::optional<WUPSConfigItemBoolean> Create(std::optional<std::string> identifier,
+    static std::optional<WUPSConfigItemBoolean> Create(std::optional<std::string_view> identifier,
                                                        std::string_view displayName,
                                                        bool defaultValue,
                                                        bool currentValue,
                                                        BooleanValueChangedCallback callback,
                                                        WUPSConfigAPIStatus &err) noexcept;
 
-    static WUPSConfigItemBoolean Create(std::optional<std::string> identifier,
+    static WUPSConfigItemBoolean Create(std::optional<std::string_view> identifier,
                                         std::string_view displayName,
                                         bool defaultValue,
                                         bool currentValue,

--- a/include/wups/config/WUPSConfigItemIntegerRange.h
+++ b/include/wups/config/WUPSConfigItemIntegerRange.h
@@ -71,7 +71,7 @@ class WUPSConfigItemIntegerRange : public WUPSConfigItem {
 
 public:
     static std::optional<WUPSConfigItemIntegerRange> Create(
-            std::optional<std::string> identifier,
+            std::optional<std::string_view> identifier,
             std::string_view displayName,
             int32_t defaultValue, int32_t currentValue,
             int32_t minValue, int32_t maxValue,
@@ -79,7 +79,7 @@ public:
             WUPSConfigAPIStatus &err) noexcept;
 
     static WUPSConfigItemIntegerRange Create(
-            std::optional<std::string> identifier,
+            std::optional<std::string_view> identifier,
             std::string_view displayName,
             int32_t defaultValue, int32_t currentValue,
             int32_t minValue, int32_t maxValue,

--- a/include/wups/config/WUPSConfigItemMultipleValues.h
+++ b/include/wups/config/WUPSConfigItemMultipleValues.h
@@ -81,21 +81,21 @@ public:
         std::string_view name;
     };
 
-    static std::optional<WUPSConfigItemMultipleValues> CreateFromIndex(std::optional<const std::string> identifier,
+    static std::optional<WUPSConfigItemMultipleValues> CreateFromIndex(std::optional<std::string_view> identifier,
                                                                        std::string_view displayName,
                                                                        int defaultValueIndex, int currentValueIndex,
                                                                        const std::span<const ValuePair> &possibleValues,
                                                                        MultipleValuesChangedCallback valuesChangedCallback,
                                                                        WUPSConfigAPIStatus &err) noexcept;
 
-    static WUPSConfigItemMultipleValues CreateFromIndex(std::optional<const std::string> identifier,
+    static WUPSConfigItemMultipleValues CreateFromIndex(std::optional<std::string_view> identifier,
                                                         std::string_view displayName,
                                                         int defaultValueIndex, int currentValueIndex,
                                                         const std::span<const ValuePair> &possibleValues,
                                                         MultipleValuesChangedCallback valuesChangedCallback);
 
     static std::optional<WUPSConfigItemMultipleValues> CreateFromValue(
-            std::optional<const std::string> identifier,
+            std::optional<std::string_view> identifier,
             std::string_view displayName,
             uint32_t defaultValue, uint32_t currentValue,
             const std::span<const ValuePair> &possibleValues,
@@ -103,7 +103,7 @@ public:
             WUPSConfigAPIStatus &err) noexcept;
 
     static WUPSConfigItemMultipleValues CreateFromValue(
-            std::optional<const std::string> identifier,
+            std::optional<std::string_view> identifier,
             std::string_view displayName,
             int32_t defaultValue, int32_t currentValue,
             const std::span<const ValuePair> &possibleValues,

--- a/libraries/libwups/WUPSConfigItemBooleanCpp.cpp
+++ b/libraries/libwups/WUPSConfigItemBooleanCpp.cpp
@@ -1,6 +1,6 @@
 #include "wups/config/WUPSConfigItemBoolean.h"
 
-std::optional<WUPSConfigItemBoolean> WUPSConfigItemBoolean::CreateEx(std::optional<std::string> identifier, std::string_view displayName, bool defaultValue, bool currentValue, BooleanValueChangedCallback callback, std::string_view trueValue, std::string_view falseValue, WUPSConfigAPIStatus &err) noexcept {
+std::optional<WUPSConfigItemBoolean> WUPSConfigItemBoolean::CreateEx(std::optional<std::string_view> identifier, std::string_view displayName, bool defaultValue, bool currentValue, BooleanValueChangedCallback callback, std::string_view trueValue, std::string_view falseValue, WUPSConfigAPIStatus &err) noexcept {
     WUPSConfigItemHandle itemHandle;
     if ((err = WUPSConfigItemBoolean_CreateEx(identifier ? identifier->data() : nullptr,
                                               displayName.data(),
@@ -13,22 +13,22 @@ std::optional<WUPSConfigItemBoolean> WUPSConfigItemBoolean::CreateEx(std::option
     }
     return WUPSConfigItemBoolean(itemHandle);
 }
-WUPSConfigItemBoolean WUPSConfigItemBoolean::CreateEx(std::optional<std::string> identifier, std::string_view displayName, bool defaultValue, bool currentValue, BooleanValueChangedCallback callback, std::string_view trueValue, std::string_view falseValue) {
+WUPSConfigItemBoolean WUPSConfigItemBoolean::CreateEx(std::optional<std::string_view> identifier, std::string_view displayName, bool defaultValue, bool currentValue, BooleanValueChangedCallback callback, std::string_view trueValue, std::string_view falseValue) {
     WUPSConfigAPIStatus err;
-    auto result = CreateEx(std::move(identifier), displayName, defaultValue, currentValue, callback, trueValue, falseValue, err);
+    auto result = CreateEx(identifier, displayName, defaultValue, currentValue, callback, trueValue, falseValue, err);
     if (!result) {
         throw std::runtime_error(std::string("Failed to create WUPSConfigItemBoolean: ").append(WUPSConfigAPI_GetStatusStr(err)));
     }
     return std::move(*result);
 }
 
-std::optional<WUPSConfigItemBoolean> WUPSConfigItemBoolean::Create(std::optional<std::string> identifier, std::string_view displayName, bool defaultValue, bool currentValue, BooleanValueChangedCallback callback, WUPSConfigAPIStatus &err) noexcept {
-    return CreateEx(std::move(identifier), displayName, defaultValue, currentValue, callback, "true", "false", err);
+std::optional<WUPSConfigItemBoolean> WUPSConfigItemBoolean::Create(std::optional<std::string_view> identifier, std::string_view displayName, bool defaultValue, bool currentValue, BooleanValueChangedCallback callback, WUPSConfigAPIStatus &err) noexcept {
+    return CreateEx(identifier, displayName, defaultValue, currentValue, callback, "true", "false", err);
 }
 
-WUPSConfigItemBoolean WUPSConfigItemBoolean::Create(std::optional<std::string> identifier, std::string_view displayName, bool defaultValue, bool currentValue, BooleanValueChangedCallback callback) {
+WUPSConfigItemBoolean WUPSConfigItemBoolean::Create(std::optional<std::string_view> identifier, std::string_view displayName, bool defaultValue, bool currentValue, BooleanValueChangedCallback callback) {
     WUPSConfigAPIStatus err = WUPSCONFIG_API_RESULT_UNKNOWN_ERROR;
-    auto res                = Create(std::move(identifier), displayName, defaultValue, currentValue, callback, err);
+    auto res                = Create(identifier, displayName, defaultValue, currentValue, callback, err);
     if (!res) {
         throw std::runtime_error(std::string("Failed to create WUPSConfigItemBoolean: ").append(WUPSConfigAPI_GetStatusStr(err)));
     }

--- a/libraries/libwups/WUPSConfigItemIntegerRangeCpp.cpp
+++ b/libraries/libwups/WUPSConfigItemIntegerRangeCpp.cpp
@@ -1,14 +1,14 @@
 #include "wups/config/WUPSConfigItemIntegerRange.h"
 
 std::optional<WUPSConfigItemIntegerRange> WUPSConfigItemIntegerRange::Create(
-        std::optional<std::string> identifier,
+        std::optional<std::string_view> identifier,
         std::string_view displayName,
         int32_t defaultValue, int32_t currentValue,
         int32_t minValue, int32_t maxValue,
         IntegerRangeValueChangedCallback valuesChangedCallback,
         WUPSConfigAPIStatus &err) noexcept {
     WUPSConfigItemHandle itemHandle;
-    if ((err = WUPSConfigItemIntegerRange_Create(identifier ? identifier->c_str() : nullptr,
+    if ((err = WUPSConfigItemIntegerRange_Create(identifier ? identifier->data() : nullptr,
                                                  displayName.data(),
                                                  defaultValue, currentValue,
                                                  minValue, maxValue,
@@ -20,13 +20,13 @@ std::optional<WUPSConfigItemIntegerRange> WUPSConfigItemIntegerRange::Create(
 }
 
 WUPSConfigItemIntegerRange WUPSConfigItemIntegerRange::Create(
-        std::optional<std::string> identifier,
+        std::optional<std::string_view> identifier,
         std::string_view displayName,
         int32_t defaultValue, int32_t currentValue,
         int32_t minValue, int32_t maxValue,
         IntegerRangeValueChangedCallback valuesChangedCallback) {
     WUPSConfigAPIStatus err = WUPSCONFIG_API_RESULT_UNKNOWN_ERROR;
-    auto result             = Create(std::move(identifier), displayName, defaultValue, currentValue, minValue, maxValue, valuesChangedCallback, err);
+    auto result             = Create(identifier, displayName, defaultValue, currentValue, minValue, maxValue, valuesChangedCallback, err);
     if (!result) {
         throw std::runtime_error(std::string("Failed to create WUPSConfigItemIntegerRange: ").append(WUPSConfigAPI_GetStatusStr(err)));
     }

--- a/libraries/libwups/WUPSConfigItemMultipleValuesCpp.cpp
+++ b/libraries/libwups/WUPSConfigItemMultipleValuesCpp.cpp
@@ -2,7 +2,7 @@
 
 
 std::optional<WUPSConfigItemMultipleValues> WUPSConfigItemMultipleValues::CreateFromIndex(
-        std::optional<const std::string> identifier,
+        std::optional<std::string_view> identifier,
         std::string_view displayName,
         int defaultValueIndex, int currentValueIndex,
         const std::span<const ValuePair> &possibleValues,
@@ -21,7 +21,7 @@ std::optional<WUPSConfigItemMultipleValues> WUPSConfigItemMultipleValues::Create
     }
     WUPSConfigItemHandle itemHandle;
     err = WUPSConfigItemMultipleValues_Create(
-            identifier ? identifier->c_str() : nullptr,
+            identifier ? identifier->data() : nullptr,
             displayName.data(),
             defaultValueIndex, currentValueIndex,
             values, (int32_t) possibleValues.size(),
@@ -35,13 +35,13 @@ std::optional<WUPSConfigItemMultipleValues> WUPSConfigItemMultipleValues::Create
 }
 
 WUPSConfigItemMultipleValues WUPSConfigItemMultipleValues::CreateFromIndex(
-        std::optional<const std::string> identifier,
+        std::optional<std::string_view> identifier,
         std::string_view displayName,
         int defaultValueIndex, int currentValueIndex,
         const std::span<const ValuePair> &possibleValues,
         MultipleValuesChangedCallback valuesChangedCallback) {
     WUPSConfigAPIStatus err = WUPSCONFIG_API_RESULT_UNKNOWN_ERROR;
-    auto result             = CreateFromIndex(std::move(identifier), displayName, defaultValueIndex, currentValueIndex, possibleValues, valuesChangedCallback, err);
+    auto result             = CreateFromIndex(identifier, displayName, defaultValueIndex, currentValueIndex, possibleValues, valuesChangedCallback, err);
     if (!result) {
         throw std::runtime_error(std::string("Failed to create WUPSConfigItemMultipleValues: ").append(WUPSConfigAPI_GetStatusStr(err)));
     }
@@ -49,7 +49,7 @@ WUPSConfigItemMultipleValues WUPSConfigItemMultipleValues::CreateFromIndex(
 }
 
 std::optional<WUPSConfigItemMultipleValues> WUPSConfigItemMultipleValues::CreateFromValue(
-        std::optional<const std::string> identifier,
+        std::optional<std::string_view> identifier,
         std::string_view displayName,
         uint32_t defaultValue, uint32_t currentValue,
         const std::span<const ValuePair> &possibleValues,
@@ -75,7 +75,7 @@ std::optional<WUPSConfigItemMultipleValues> WUPSConfigItemMultipleValues::Create
         return std::nullopt;
     }
 
-    return WUPSConfigItemMultipleValues::CreateFromIndex(std::move(identifier),
+    return WUPSConfigItemMultipleValues::CreateFromIndex(identifier,
                                                          displayName,
                                                          defaultIndex, currentValueIndex,
                                                          possibleValues,
@@ -84,12 +84,12 @@ std::optional<WUPSConfigItemMultipleValues> WUPSConfigItemMultipleValues::Create
 }
 
 WUPSConfigItemMultipleValues WUPSConfigItemMultipleValues::CreateFromValue(
-        std::optional<const std::string> identifier, std::string_view displayName,
+        std::optional<std::string_view> identifier, std::string_view displayName,
         int32_t defaultValue, int32_t currentValue,
         const std::span<const ValuePair> &possibleValues,
         MultipleValuesChangedCallback valuesChangedCallback) {
     WUPSConfigAPIStatus err = WUPSCONFIG_API_RESULT_UNKNOWN_ERROR;
-    auto result             = CreateFromValue(std::move(identifier),
+    auto result             = CreateFromValue(identifier,
                                               displayName,
                                               defaultValue, currentValue,
                                               possibleValues,


### PR DESCRIPTION
Using std::string in the function signatures forces the caller to heap-allocate their string, even though most callers will just be using a string literal (-> in .data). Since the backend calls `->data()` then `strdup`, it doesn't actually need to be heap-allocated, we can use the literal directly.

In plugins with very minimal code (e.g. just a config menu) this brings in all of the exception handling machinery associated with std::string and operator new, which is a substantial cost in such minimal cases.

Arguably the correct pick here is `const char *` since the length information in the std::string_view will just be discarded, but we'll keep it in case some internal refactoring happens later.